### PR TITLE
Remove quotes around test script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "server.js",
 	"scripts": {
 		"start": "node server.js",
-		"test": "\"mocha --timeout 5000 --recursive --exit --ui tdd tests/\""
+		"test": "mocha --timeout 5000 --recursive --exit --ui tdd tests/"
 	},
 	"dependencies": {
 		"body-parser": "^1.19.0",


### PR DESCRIPTION
With the previous value of `test`, the tests could not actually run.

```log
 npm run test

> freecodecamp-issue-tracker@1.0.0 test /home/runner/freeCodeCamp-Issue-Tracker
> "mocha --timeout 5000 --recursive --exit --ui tdd tests/"

sh: 1: mocha --timeout 5000 --recursive --exit --ui tdd tests/: not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! freecodecamp-issue-tracker@1.0.0 test: `"mocha --timeout 5000 --recursive --exit --ui tdd tests/"`
```

Removing the quotes allows the intended behavior.